### PR TITLE
Update api

### DIFF
--- a/api-examples.sh
+++ b/api-examples.sh
@@ -4,23 +4,23 @@ url=http://localhost:5000
 
 echo "-- get app --"
 curl -i $url
-echo "\n"
+echo ; echo
 
 echo "-- browser tries to get list --"
 curl -i \
   $url/list/get-a-list
-echo "\n"
+echo ; echo
 
 echo "-- app tries to get list --"
 curl -i \
-  -H "Content-Type: application/json" \
-  $url/list/get-a-list
-echo "\n"
+  -H "Accept: application/json" \
+  $url/api/v1/list/get-a-list
+echo ; echo
 
 echo "-- app posts to list --"
 curl -i \
-  -X POST \
+  -X PUT \
   -H "Content-Type: application/json" \
-  -d '{"items":[]}' \
-  $url/list/post-to-a-list
-echo ""
+  -d '{"items":["item 1"]}' \
+  $url/api/v1/list/post-to-a-list
+echo ; echo

--- a/api-examples.sh
+++ b/api-examples.sh
@@ -6,21 +6,37 @@ echo "-- get app --"
 curl -i $url
 echo ; echo
 
-echo "-- browser tries to get list --"
+echo "-- get app with list route --"
 curl -i \
   $url/list/get-a-list
 echo ; echo
 
-echo "-- app tries to get list --"
-curl -i \
-  -H "Accept: application/json" \
-  $url/api/v1/list/get-a-list
-echo ; echo
-
-echo "-- app posts to list --"
+echo "-- api: put empty list --"
 curl -i \
   -X PUT \
   -H "Content-Type: application/json" \
-  -d '{"items":["item 1"]}' \
-  $url/api/v1/list/post-to-a-list
+  -d '{"items":[]}' \
+  $url/api/v1/list/api-examples-list
+echo ; echo
+
+echo "-- api: put list --"
+curl -i \
+  -X PUT \
+  -H "Content-Type: application/json" \
+  -d '{"items":[{"description":"item1","completed":false}]}' \
+  $url/api/v1/list/api-examples-list
+echo ; echo
+
+echo "-- api: get list --"
+curl -i \
+  -H "Accept: application/json" \
+  $url/api/v1/list/api-examples-list
+echo ; echo
+
+echo "-- api: put bad list --"
+curl -i \
+  -X PUT \
+  -H "Content-Type: application/json" \
+  -d '{"items":[{"description":"item1","completed":"not a boolean"}]}' \
+  $url/api/v1/list/api-examples-list
 echo ; echo

--- a/lemongrab.py
+++ b/lemongrab.py
@@ -16,6 +16,7 @@ schema = {
                     'description': {'type': 'string'},
                     'completed': {'type': 'boolean'},
                 },
+                'required': ['description', 'completed'],
             },
         },
     },
@@ -61,7 +62,7 @@ def put(listname):
         data_store[listname] = lst['items']
         return 'Saved "{}"'.format(listname)
     except ValidationError:
-        return "Invalid JSON schema", 403
+        return 'Invalid JSON schema', 403
 
 @app.route('/api/v1/list/<listname>', methods=['GET', 'PUT'])
 def list_request(listname):

--- a/lemongrab.py
+++ b/lemongrab.py
@@ -59,10 +59,11 @@ def put(listname):
     lst = request.get_json()
     try:
         validate(lst, schema)
-        data_store[listname] = lst['items']
-        return 'Saved "{}"'.format(listname)
     except ValidationError:
         return 'Invalid JSON schema', 403
+    data_store[listname] = lst['items']
+    return 'Saved "{}"'.format(listname)
+
 
 @app.route('/api/v1/list/<listname>', methods=['GET', 'PUT'])
 def list_request(listname):

--- a/lemongrab.py
+++ b/lemongrab.py
@@ -45,10 +45,16 @@ def load_app_with_list(listname):
     return load_app()
 
 def get(listname):
+    """
+    Get a list by listname.
+    """
     lst = {'items': data_store[listname]}
     return json.jsonify(lst)
 
 def put(listname):
+    """
+    Save a list by listname.
+    """
     lst = request.get_json()
     try:
         validate(lst, schema)
@@ -59,6 +65,9 @@ def put(listname):
 
 @app.route('/api/v1/list/<listname>', methods=['GET', 'PUT'])
 def list_request(listname):
+    """
+    List resource method dispatcher.
+    """
     return {'GET': get,
             'PUT': put}.get(request.method)(listname)
 

--- a/lemongrab_tests.py
+++ b/lemongrab_tests.py
@@ -1,0 +1,86 @@
+#lemongrab_tests.py
+from functools import partial
+import json
+import os
+import unittest
+from collections import defaultdict
+
+import lemongrab
+
+class LemongrabTestCase(unittest.TestCase):
+
+    def setUp(self):
+        lemongrab.app.config['TESTING'] = True
+        self.app = lemongrab.app.test_client()
+
+    def tearDown(self):
+        # reset the "data_store"
+        lemongrab.data_store = defaultdict(list)
+
+    def test_load_app(self):
+        resp = self.app.get('/')
+        self.assertEqual('text/html', resp.mimetype)
+        self.assertEqual(200, resp.status_code)
+
+    def test_load_app_via_list_resource(self):
+        resp = self.app.get('/list/test-list')
+        self.assertEqual('text/html', resp.mimetype)
+        self.assertEqual(200, resp.status_code)
+
+    def test_get_list_that_is_not_yet_saved(self):
+        resp = self.app.get('/api/v1/list/test-list')
+        self.assertEqual('application/json', resp.mimetype)
+        self.assertEqual(200, resp.status_code)
+
+    def test_put_new_list(self):
+        data = json.dumps(
+            {'items': [{'description': 'put_test', 'completed': True}]}
+        )
+        resp = self.app.put(
+            path='/api/v1/list/test-list',
+            content_type='application/json',
+            data=data
+        )
+        self.assertEqual(200, resp.status_code)
+        self.assertEqual('Saved "test-list"',resp.data)
+
+    def test_put_then_get_list(self):
+        path = '/api/v1/list/test-list'
+        expect = {'items': [
+            {'description': 'get_test_1', 'completed': False},
+            {'description': 'get_test_2', 'completed': True},
+        ]}
+        self.app.put(
+            path=path,
+            content_type='application/json',
+            data=json.dumps(expect)
+        )
+        resp = self.app.get(path)
+        actual = json.loads(resp.data)
+        self.assertEqual(expect, actual)
+
+    def test_put_empty_list(self):
+        resp = self.app.put(
+            path='/api/v1/list/test-list',
+            content_type='application/json',
+            data=json.dumps({'items': []})
+        )
+        self.assertEqual(200, resp.status_code)
+        self.assertEqual('Saved "test-list"',resp.data)
+
+    def test_put_with_bad_json_schema(self):
+        put = partial(
+            self.app.put,
+            path='/api/v1/list/test-list',
+            content_type='application/json',
+        )
+
+        resp = put(data='{}')
+        self.assertEqual(403, resp.status_code)
+        resp = put(data='{"item": []}')
+        self.assertEqual(403, resp.status_code)
+        resp = put(data='{"items": [{"description":"test"}]}')
+        self.assertEqual(403, resp.status_code)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,6 @@ Flask==0.10.1
 gunicorn==19.2.1
 itsdangerous==0.24
 Jinja2==2.7.3
+jsonschema==2.4.0
 MarkupSafe==0.23
 Werkzeug==0.10.1

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,0 +1,3 @@
+#!/bin/sh -e
+
+python lemongrab_tests.py


### PR DESCRIPTION
Use dedicated routing (instead of trying to use header content-type): `/api/v1/list/:name`

Other server updates:
- includes a temporary "data store" for testing persistence while the server is running
- validates request json schema before saving
